### PR TITLE
websocket reconnect 확인

### DIFF
--- a/back/src/main/java/com/undefined/undefined/global/config/web3/WebSocketConfig.java
+++ b/back/src/main/java/com/undefined/undefined/global/config/web3/WebSocketConfig.java
@@ -36,7 +36,8 @@ public class WebSocketConfig {
 
         Runnable onClose = () -> {
             log.warn("WebSocket 연결이 종료됨. 재연결 시도...");
-            connectWebSocketService(webSocketService);
+            // 기존 스레드는 close 되면서 종료됨. 별도의 스레드에서 재연결
+            new Thread(() -> connectWebSocketService(webSocketService)).start();
         };
 
         try {


### PR DESCRIPTION
## 📝 Summary
기존 스레드가 없어서 웹소켓 재연결 실패 -> 새로운 스레드 할당